### PR TITLE
feat: Google Maps import improvements + Places API fallback

### DIFF
--- a/app/(app)/share-target/page.tsx
+++ b/app/(app)/share-target/page.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { createClient } from '@/lib/supabase/client'
+import { isMapsUrl } from '@/lib/maps/parseGoogleMapsUrl'
+
+/**
+ * PWA Web Share Target landing page.
+ *
+ * When a user taps "Share" in Google Maps and selects Open Fly, the OS opens:
+ *   /share-target?url=<maps-url>&title=<place-name>
+ *
+ * We find their most recent active trip and redirect to its Lists page
+ * with the maps URL encoded in the query string so PlacesPanel can
+ * auto-open the import dialog.
+ */
+export default function ShareTargetPage() {
+  const router = useRouter()
+  const params = useSearchParams()
+
+  useEffect(() => {
+    async function handle() {
+      const url   = params.get('url')   ?? ''
+      const text  = params.get('text')  ?? ''
+      const title = params.get('title') ?? ''
+
+      // Extract the maps link — it may be in url or embedded in text
+      const mapsLink = [url, text].find(s => isMapsUrl(s)) ?? ''
+
+      // Find the user's most recent trip to default to
+      const supabase = createClient()
+      const { data: { user } } = await supabase.auth.getUser()
+      if (!user) { router.replace('/login'); return }
+
+      const { data: membership } = await supabase
+        .from('trip_members')
+        .select('trip_id')
+        .eq('user_id', user.id)
+        .order('joined_at', { ascending: false })
+        .limit(1)
+        .single()
+
+      const tripId = membership?.trip_id
+      if (!tripId) { router.replace('/trips'); return }
+
+      const query = new URLSearchParams()
+      if (mapsLink) query.set('import_url', mapsLink)
+      else if (title) query.set('import_url', text || url)
+
+      router.replace(`/trips/${tripId}/lists?${query.toString()}`)
+    }
+
+    handle()
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <p className="text-sm text-muted-foreground">Opening your trip…</p>
+    </div>
+  )
+}

--- a/app/api/places-details/route.ts
+++ b/app/api/places-details/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+/**
+ * Fetches basic place details from Google Places API using a Place ID.
+ * Only called as a fallback when URL parsing fails to extract a name.
+ * Requests only `displayName` and `formattedAddress` (Basic tier — lowest cost).
+ */
+export async function GET(request: NextRequest) {
+  const placeId = request.nextUrl.searchParams.get('place_id')
+  if (!placeId) return NextResponse.json({ error: 'place_id is required' }, { status: 400 })
+
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY
+  if (!apiKey) return NextResponse.json({ error: 'Places API not configured' }, { status: 503 })
+
+  try {
+    const res = await fetch(
+      `https://places.googleapis.com/v1/places/${encodeURIComponent(placeId)}`,
+      {
+        headers: {
+          'X-Goog-Api-Key': apiKey,
+          // Request only the cheapest Basic-tier fields to minimize cost
+          'X-Goog-FieldMask': 'displayName,formattedAddress',
+        },
+      }
+    )
+
+    if (!res.ok) {
+      return NextResponse.json({ error: 'Places API request failed' }, { status: res.status })
+    }
+
+    const data = await res.json()
+    return NextResponse.json({
+      name: data.displayName?.text ?? null,
+      address: data.formattedAddress ?? null,
+    })
+  } catch {
+    return NextResponse.json({ error: 'Failed to fetch place details' }, { status: 500 })
+  }
+}

--- a/app/api/resolve-url/route.ts
+++ b/app/api/resolve-url/route.ts
@@ -9,7 +9,15 @@ export async function GET(request: NextRequest) {
   if (!url) return NextResponse.json({ error: 'url is required' }, { status: 400 })
 
   try {
-    const res = await fetch(url, { method: 'HEAD', redirect: 'follow' })
+    // Use GET (not HEAD) — Google share links may not redirect on HEAD.
+    // Add a browser User-Agent so Google's CDN doesn't block or short-circuit the redirect.
+    const res = await fetch(url, {
+      method: 'GET',
+      redirect: 'follow',
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      },
+    })
     return NextResponse.json({ resolvedUrl: res.url })
   } catch {
     return NextResponse.json({ error: 'Failed to resolve URL' }, { status: 400 })

--- a/app/api/resolve-url/route.ts
+++ b/app/api/resolve-url/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+/**
+ * Resolves a (potentially shortened) URL to its final destination.
+ * Used to expand maps.app.goo.gl short links before parsing.
+ */
+export async function GET(request: NextRequest) {
+  const url = request.nextUrl.searchParams.get('url')
+  if (!url) return NextResponse.json({ error: 'url is required' }, { status: 400 })
+
+  try {
+    const res = await fetch(url, { method: 'HEAD', redirect: 'follow' })
+    return NextResponse.json({ resolvedUrl: res.url })
+  } catch {
+    return NextResponse.json({ error: 'Failed to resolve URL' }, { status: 400 })
+  }
+}

--- a/components/lists/PlacesPanel.tsx
+++ b/components/lists/PlacesPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useSearchParams } from 'next/navigation'
-import { Plus, Trash2, MapPin, Star, UtensilsCrossed, Landmark, TreePine, ShoppingBag, Wifi, CheckCircle2, Clock, MoreVertical, Search, ChevronRight, Pencil, ThumbsUp, ThumbsDown, CalendarClock, Sun, Sunset, Moon, Layers, Link2, Loader2 } from 'lucide-react'
+import { Plus, Trash2, MapPin, Star, UtensilsCrossed, Landmark, TreePine, ShoppingBag, Wifi, CheckCircle2, Clock, MoreVertical, Search, ChevronRight, Pencil, ThumbsUp, ThumbsDown, CalendarClock, Sun, Sunset, Moon, Layers, Link2, Loader2, ExternalLink } from 'lucide-react'
 import { toast } from 'sonner'
 import type { PlaceWithVotes, PlaceCategory, PlaceStatus, TimeOfDay, PlaceDuration, MealType } from '@/types'
 import { Button } from '@/components/ui/button'
@@ -37,7 +37,7 @@ export default function PlacesPanel({ tripId, initialPlaces }: Props) {
   const [saving, setSaving]           = useState(false)
   const [form, setForm]               = useState({
     name: '', location: '', lng: null as number | null, lat: null as number | null,
-    notes: '', url: '',
+    notes: '', url: '', place_id: null as string | null,
     reservation_needed: false,
     time_of_day: null as TimeOfDay | null,
     duration: null as PlaceDuration | null,
@@ -82,7 +82,7 @@ export default function PlacesPanel({ tripId, initialPlaces }: Props) {
   const set = (field: string) => (e: React.ChangeEvent<HTMLInputElement>) =>
     setForm(f => ({ ...f, [field]: e.target.value }))
 
-  const emptyForm = { name: '', location: '', lng: null as number | null, lat: null as number | null, notes: '', url: '', reservation_needed: false, time_of_day: null as TimeOfDay | null, duration: null as PlaceDuration | null, meal_type: null as MealType | null }
+  const emptyForm = { name: '', location: '', lng: null as number | null, lat: null as number | null, notes: '', url: '', place_id: null as string | null, reservation_needed: false, time_of_day: null as TimeOfDay | null, duration: null as PlaceDuration | null, meal_type: null as MealType | null }
 
   async function handleMapsUrl(raw: string) {
     if (!raw.trim() || !isMapsUrl(raw.trim())) return
@@ -94,17 +94,39 @@ export default function PlacesPanel({ tripId, initialPlaces }: Props) {
         if (res.ok) resolved = (await res.json()).resolvedUrl ?? resolved
       }
       const parsed = parseGoogleMapsUrl(resolved)
+      // Discard names that look like hash IDs (no spaces, only alphanum, long) — these are
+      // internal Google identifiers, not human-readable place names.
+      const looksLikeId = (s: string) => /^[A-Za-z0-9]{8,}$/.test(s)
+      let placeName = parsed.name && !looksLikeId(parsed.name) ? parsed.name : null
+      let placeAddress = parsed.address
+
+      // Fallback: if we have a Place ID but no clean name, call Places Details API (one cheap call)
+      if (!placeName && parsed.place_id) {
+        try {
+          const detailsRes = await fetch(`/api/places-details?place_id=${encodeURIComponent(parsed.place_id)}`)
+          if (detailsRes.ok) {
+            const details = await detailsRes.json()
+            placeName = details.name ?? null
+            placeAddress = details.address ?? placeAddress
+          }
+        } catch {
+          // non-fatal — user can type the name manually
+        }
+      }
+
       setForm(f => ({
         ...f,
-        name:     parsed.name     ?? f.name,
-        location: parsed.address  ?? f.location,
-        lat:      parsed.lat      ?? f.lat,
-        lng:      parsed.lng      ?? f.lng,
+        name:     placeName      ?? f.name,
+        location: placeAddress   ?? f.location,
+        lat:      parsed.lat     ?? f.lat,
+        lng:      parsed.lng     ?? f.lng,
         url:      resolved,
+        place_id: parsed.place_id ?? f.place_id,
       }))
       setMapsUrl('')
-      if (parsed.name) toast.success(`Imported "${parsed.name}" from Maps`)
-      else toast.info('Coordinates imported — add a name below')
+      if (placeName) toast.success(`Imported "${placeName}" from Maps`)
+      else if (parsed.lat && parsed.lng) toast.info('Location pinned — enter the place name below')
+      else toast.info('Paste a Google or Apple Maps link to import')
     } catch {
       toast.error('Could not read that Maps link')
     } finally {
@@ -123,7 +145,7 @@ export default function PlacesPanel({ tripId, initialPlaces }: Props) {
     setEditingPlace(place)
     setForm({
       name: place.name, location: place.location ?? '', lng: place.lng ?? null, lat: place.lat ?? null,
-      notes: place.notes ?? '', url: place.url ?? '',
+      notes: place.notes ?? '', url: place.url ?? '', place_id: place.place_id ?? null,
       reservation_needed: place.reservation_needed ?? false,
       time_of_day: place.time_of_day ?? null,
       duration: place.duration ?? null,
@@ -143,7 +165,7 @@ export default function PlacesPanel({ tripId, initialPlaces }: Props) {
     setSaving(true)
     try {
       if (editingPlace) {
-        const updates = { name: form.name.trim(), location: form.location || null, lng: form.lng, lat: form.lat, notes: form.notes || null, url: form.url || null, reservation_needed: form.reservation_needed, time_of_day: form.time_of_day, duration: form.duration, meal_type: form.meal_type }
+        const updates = { name: form.name.trim(), location: form.location || null, lng: form.lng, lat: form.lat, notes: form.notes || null, url: form.url || null, place_id: form.place_id || null, reservation_needed: form.reservation_needed, time_of_day: form.time_of_day, duration: form.duration, meal_type: form.meal_type }
         const res = await fetch(`/api/trips/${tripId}/places/${editingPlace.id}`, {
           method: 'PATCH',
           headers: { 'Content-Type': 'application/json' },
@@ -580,9 +602,23 @@ export default function PlacesPanel({ tripId, initialPlaces }: Props) {
                   >
                     <ThumbsDown className={`h-3.5 w-3.5 ${place.user_vote === -1 ? 'fill-destructive' : ''}`} />
                   </button>
-                  {place.vote_count >= 2 && (
-                    <span className="ml-auto text-xs font-medium text-amber-600 bg-amber-50 px-1.5 py-0.5 rounded-full">Popular</span>
-                  )}
+                  <div className="ml-auto flex items-center gap-1.5">
+                    {place.vote_count >= 2 && (
+                      <span className="text-xs font-medium text-amber-600 bg-amber-50 px-1.5 py-0.5 rounded-full">Popular</span>
+                    )}
+                    {(place.url || (place.lat && place.lng)) && (
+                      <a
+                        href={place.url || `https://www.google.com/maps/search/?api=1&query=${place.lat},${place.lng}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title="Open in Maps"
+                        className="p-1 rounded text-muted-foreground/50 hover:text-foreground transition-colors"
+                        onClick={e => e.stopPropagation()}
+                      >
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </a>
+                    )}
+                  </div>
                 </div>
               </div>
             ))}

--- a/components/lists/PlacesPanel.tsx
+++ b/components/lists/PlacesPanel.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState } from 'react'
-import { Plus, Trash2, MapPin, Star, UtensilsCrossed, Landmark, TreePine, ShoppingBag, Wifi, CheckCircle2, Clock, MoreVertical, Search, ChevronRight, Pencil, ThumbsUp, ThumbsDown, CalendarClock, Sun, Sunset, Moon, Layers, HelpCircle } from 'lucide-react'
+import { useState, useEffect } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { Plus, Trash2, MapPin, Star, UtensilsCrossed, Landmark, TreePine, ShoppingBag, Wifi, CheckCircle2, Clock, MoreVertical, Search, ChevronRight, Pencil, ThumbsUp, ThumbsDown, CalendarClock, Sun, Sunset, Moon, Layers, Link2, Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import type { PlaceWithVotes, PlaceCategory, PlaceStatus, TimeOfDay, PlaceDuration, MealType } from '@/types'
 import { Button } from '@/components/ui/button'
@@ -10,6 +11,7 @@ import { Label } from '@/components/ui/label'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import PlaceSearchInput from '@/components/ui/PlaceSearchInput'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { parseGoogleMapsUrl, isMapsUrl, isShortMapsUrl } from '@/lib/maps/parseGoogleMapsUrl'
 
 const CATEGORIES: { id: PlaceCategory; label: string; icon: React.ElementType; color: string; iconBg: string }[] = [
   { id: 'food_drink',    label: 'Food & Drink',   icon: UtensilsCrossed, color: 'text-orange-600', iconBg: 'bg-orange-100' },
@@ -25,6 +27,8 @@ interface Props {
 }
 
 export default function PlacesPanel({ tripId, initialPlaces }: Props) {
+  const searchParams = useSearchParams()
+
   const [places, setPlaces]           = useState<PlaceWithVotes[]>(initialPlaces)
   const [activeCategory, setActiveCategory] = useState<PlaceCategory>('food_drink')
   const [search, setSearch]           = useState('')
@@ -46,6 +50,20 @@ export default function PlacesPanel({ tripId, initialPlaces }: Props) {
   const [filterDuration, setFilterDuration]       = useState<PlaceDuration | null>(null)
   const [filterMealType, setFilterMealType]       = useState<MealType | null>(null)
 
+  // Maps URL import
+  const [mapsUrl, setMapsUrl]       = useState('')
+  const [mapsLoading, setMapsLoading] = useState(false)
+
+  // Auto-import when arriving via PWA share target
+  useEffect(() => {
+    const importUrl = searchParams.get('import_url')
+    if (importUrl) {
+      setMapsUrl(importUrl)
+      setDialogOpen(true)
+      handleMapsUrl(importUrl)
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
   const mapboxToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN ?? ''
 
   const activeCfg = CATEGORIES.find(c => c.id === activeCategory)!
@@ -66,9 +84,38 @@ export default function PlacesPanel({ tripId, initialPlaces }: Props) {
 
   const emptyForm = { name: '', location: '', lng: null as number | null, lat: null as number | null, notes: '', url: '', reservation_needed: false, time_of_day: null as TimeOfDay | null, duration: null as PlaceDuration | null, meal_type: null as MealType | null }
 
+  async function handleMapsUrl(raw: string) {
+    if (!raw.trim() || !isMapsUrl(raw.trim())) return
+    setMapsLoading(true)
+    try {
+      let resolved = raw.trim()
+      if (isShortMapsUrl(resolved)) {
+        const res = await fetch(`/api/resolve-url?url=${encodeURIComponent(resolved)}`)
+        if (res.ok) resolved = (await res.json()).resolvedUrl ?? resolved
+      }
+      const parsed = parseGoogleMapsUrl(resolved)
+      setForm(f => ({
+        ...f,
+        name:     parsed.name     ?? f.name,
+        location: parsed.address  ?? f.location,
+        lat:      parsed.lat      ?? f.lat,
+        lng:      parsed.lng      ?? f.lng,
+        url:      resolved,
+      }))
+      setMapsUrl('')
+      if (parsed.name) toast.success(`Imported "${parsed.name}" from Maps`)
+      else toast.info('Coordinates imported — add a name below')
+    } catch {
+      toast.error('Could not read that Maps link')
+    } finally {
+      setMapsLoading(false)
+    }
+  }
+
   function openAddDialog() {
     setEditingPlace(null)
     setForm(emptyForm)
+    setMapsUrl('')
     setDialogOpen(true)
   }
 
@@ -237,6 +284,43 @@ export default function PlacesPanel({ tripId, initialPlaces }: Props) {
                   <DialogTitle>{editingPlace ? 'Edit place' : 'Add a place to visit'}</DialogTitle>
                 </DialogHeader>
                 <div className="space-y-3 mt-2">
+                  {/* Google / Apple Maps URL import */}
+                  {!editingPlace && (
+                    <div className="rounded-lg border border-dashed bg-muted/30 px-3 py-2.5">
+                      <p className="text-xs text-muted-foreground mb-1.5">Import from Google or Apple Maps</p>
+                      <div className="flex gap-2">
+                        <div className="relative flex-1">
+                          <Link2 className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" />
+                          <input
+                            type="url"
+                            value={mapsUrl}
+                            onChange={e => setMapsUrl(e.target.value)}
+                            onPaste={e => {
+                              const pasted = e.clipboardData.getData('text')
+                              if (isMapsUrl(pasted)) {
+                                e.preventDefault()
+                                setMapsUrl(pasted)
+                                handleMapsUrl(pasted)
+                              }
+                            }}
+                            placeholder="Paste a Maps link…"
+                            className="w-full pl-8 h-8 text-sm rounded-md border border-input bg-background px-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          />
+                        </div>
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          className="h-8 shrink-0"
+                          disabled={mapsLoading || !mapsUrl.trim()}
+                          onClick={() => handleMapsUrl(mapsUrl)}
+                        >
+                          {mapsLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : 'Import'}
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+
                   <div className="space-y-1">
                     <Label>Search or enter a place *</Label>
                     <PlaceSearchInput

--- a/controllers/list.controller.ts
+++ b/controllers/list.controller.ts
@@ -43,7 +43,7 @@ export async function getPlaces(tripId: string): Promise<Place[]> {
 export async function createPlace(
   tripId: string,
   userId: string,
-  data: { name: string; category: PlaceCategory; location?: string; lng?: number | null; lat?: number | null; notes?: string; url?: string; reservation_needed?: boolean; time_of_day?: TimeOfDay | null; duration?: PlaceDuration | null; meal_type?: MealType | null }
+  data: { name: string; category: PlaceCategory; location?: string; lng?: number | null; lat?: number | null; notes?: string; url?: string; place_id?: string | null; reservation_needed?: boolean; time_of_day?: TimeOfDay | null; duration?: PlaceDuration | null; meal_type?: MealType | null }
 ): Promise<Place> {
   return ListModel.createPlace({
     trip_id: tripId,
@@ -57,6 +57,7 @@ export async function createPlace(
     status: 'pending',
     rating: null,
     url: data.url ?? null,
+    place_id: data.place_id ?? null,
     reservation_needed: data.reservation_needed ?? false,
     time_of_day: data.time_of_day ?? null,
     duration: data.duration ?? null,
@@ -66,7 +67,7 @@ export async function createPlace(
 
 export async function updatePlace(
   placeId: string,
-  updates: Partial<Pick<Place, 'name' | 'location' | 'notes' | 'status' | 'rating' | 'url' | 'category' | 'reservation_needed' | 'time_of_day' | 'duration' | 'meal_type'>>
+  updates: Partial<Pick<Place, 'name' | 'location' | 'notes' | 'status' | 'rating' | 'url' | 'category' | 'reservation_needed' | 'time_of_day' | 'duration' | 'meal_type' | 'place_id'>>
 ): Promise<Place> {
   return ListModel.updatePlace(placeId, updates)
 }

--- a/lib/maps/parseGoogleMapsUrl.ts
+++ b/lib/maps/parseGoogleMapsUrl.ts
@@ -3,26 +3,35 @@ export interface ParsedMapPlace {
   address: string | null
   lat: number | null
   lng: number | null
+  place_id: string | null
   url: string
 }
 
 /**
- * Extracts place name and coordinates from a Google Maps URL.
+ * Extracts place name, coordinates, and Place ID from a Google Maps URL.
  *
  * Handles these formats:
  *   https://www.google.com/maps/place/Ichiran+Ramen/@35.6595,139.7005,17z/
- *   https://www.google.com/maps/place/Some+Place/data=...
+ *   https://www.google.com/maps/place/Some+Place/data=!3m1!...!1sChIJ...
  *   https://maps.google.com/?q=35.6595,139.7005
  *   https://www.google.com/maps?q=Eiffel+Tower
  *   https://maps.apple.com/?ll=48.8584,2.2945&q=Eiffel+Tower
  */
 export function parseGoogleMapsUrl(rawUrl: string): ParsedMapPlace {
-  const result: ParsedMapPlace = { name: null, address: null, lat: null, lng: null, url: rawUrl }
+  const result: ParsedMapPlace = { name: null, address: null, lat: null, lng: null, place_id: null, url: rawUrl }
 
   let url: URL
   try {
     url = new URL(rawUrl)
   } catch {
+    return result
+  }
+
+  // ── Google Search (share.google short links resolve here) ──────────────────
+  // e.g. google.com/search?q=Fatt+Pundit&kgmid=/g/11p01vq1f6&output=search
+  if (url.hostname === 'www.google.com' && url.pathname === '/search') {
+    const q = url.searchParams.get('q')
+    if (q) result.name = decodeURIComponent(q.replace(/\+/g, ' '))
     return result
   }
 
@@ -39,6 +48,13 @@ export function parseGoogleMapsUrl(rawUrl: string): ParsedMapPlace {
   }
 
   // ── Google Maps ────────────────────────────────────────────────────────────
+
+  // Place ID — embedded in the `data` segment as !1sChIJ... or in the pb parameter
+  // Google Place IDs start with "ChIJ" and are base64url encoded
+  const placeIdMatch = rawUrl.match(/!1s(ChIJ[A-Za-z0-9_-]+)/)
+  if (placeIdMatch) {
+    result.place_id = placeIdMatch[1]
+  }
 
   // Format: /maps/place/{name}/@{lat},{lng},{zoom}z
   const placeMatch = url.pathname.match(/\/maps\/place\/([^/@]+)/)
@@ -76,6 +92,7 @@ export function isMapsUrl(url: string): boolean {
     const { hostname } = new URL(url)
     return (
       hostname === 'maps.app.goo.gl' ||
+      hostname === 'share.google' ||
       hostname === 'maps.google.com' ||
       hostname.endsWith('google.com') && url.includes('/maps') ||
       hostname === 'maps.apple.com'
@@ -88,7 +105,8 @@ export function isMapsUrl(url: string): boolean {
 /** Returns true if the URL is a short link that needs server-side resolution */
 export function isShortMapsUrl(url: string): boolean {
   try {
-    return new URL(url).hostname === 'maps.app.goo.gl'
+    const { hostname } = new URL(url)
+    return hostname === 'maps.app.goo.gl' || hostname === 'share.google'
   } catch {
     return false
   }

--- a/lib/maps/parseGoogleMapsUrl.ts
+++ b/lib/maps/parseGoogleMapsUrl.ts
@@ -1,0 +1,95 @@
+export interface ParsedMapPlace {
+  name: string | null
+  address: string | null
+  lat: number | null
+  lng: number | null
+  url: string
+}
+
+/**
+ * Extracts place name and coordinates from a Google Maps URL.
+ *
+ * Handles these formats:
+ *   https://www.google.com/maps/place/Ichiran+Ramen/@35.6595,139.7005,17z/
+ *   https://www.google.com/maps/place/Some+Place/data=...
+ *   https://maps.google.com/?q=35.6595,139.7005
+ *   https://www.google.com/maps?q=Eiffel+Tower
+ *   https://maps.apple.com/?ll=48.8584,2.2945&q=Eiffel+Tower
+ */
+export function parseGoogleMapsUrl(rawUrl: string): ParsedMapPlace {
+  const result: ParsedMapPlace = { name: null, address: null, lat: null, lng: null, url: rawUrl }
+
+  let url: URL
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return result
+  }
+
+  // ── Apple Maps ─────────────────────────────────────────────────────────────
+  if (url.hostname === 'maps.apple.com') {
+    const ll = url.searchParams.get('ll')
+    const q  = url.searchParams.get('q')
+    if (ll) {
+      const [lat, lng] = ll.split(',').map(Number)
+      if (!isNaN(lat) && !isNaN(lng)) { result.lat = lat; result.lng = lng }
+    }
+    if (q) result.name = decodeURIComponent(q.replace(/\+/g, ' '))
+    return result
+  }
+
+  // ── Google Maps ────────────────────────────────────────────────────────────
+
+  // Format: /maps/place/{name}/@{lat},{lng},{zoom}z
+  const placeMatch = url.pathname.match(/\/maps\/place\/([^/@]+)/)
+  if (placeMatch) {
+    result.name = decodeURIComponent(placeMatch[1].replace(/\+/g, ' '))
+  }
+
+  // Coordinates from @lat,lng,zoom
+  const coordMatch = url.pathname.match(/@(-?\d+\.\d+),(-?\d+\.\d+)/)
+  if (coordMatch) {
+    result.lat = parseFloat(coordMatch[1])
+    result.lng = parseFloat(coordMatch[2])
+  }
+
+  // Fallback: ?q=lat,lng or ?q=place+name
+  if (!result.lat || !result.lng) {
+    const q = url.searchParams.get('q')
+    if (q) {
+      const latLng = q.match(/^(-?\d+\.\d+),(-?\d+\.\d+)$/)
+      if (latLng) {
+        result.lat = parseFloat(latLng[1])
+        result.lng = parseFloat(latLng[2])
+      } else if (!result.name) {
+        result.name = decodeURIComponent(q.replace(/\+/g, ' '))
+      }
+    }
+  }
+
+  return result
+}
+
+/** Returns true if the URL looks like a Google/Apple Maps link */
+export function isMapsUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url)
+    return (
+      hostname === 'maps.app.goo.gl' ||
+      hostname === 'maps.google.com' ||
+      hostname.endsWith('google.com') && url.includes('/maps') ||
+      hostname === 'maps.apple.com'
+    )
+  } catch {
+    return false
+  }
+}
+
+/** Returns true if the URL is a short link that needs server-side resolution */
+export function isShortMapsUrl(url: string): boolean {
+  try {
+    return new URL(url).hostname === 'maps.app.goo.gl'
+  } catch {
+    return false
+  }
+}

--- a/models/list.model.ts
+++ b/models/list.model.ts
@@ -73,7 +73,7 @@ export async function createPlace(
 
 export async function updatePlace(
   placeId: string,
-  updates: Partial<Pick<Place, 'name' | 'location' | 'lng' | 'lat' | 'notes' | 'status' | 'rating' | 'url' | 'category' | 'reservation_needed' | 'time_of_day' | 'duration' | 'meal_type'>>
+  updates: Partial<Pick<Place, 'name' | 'location' | 'lng' | 'lat' | 'notes' | 'status' | 'rating' | 'url' | 'category' | 'reservation_needed' | 'time_of_day' | 'duration' | 'meal_type' | 'place_id'>>
 ): Promise<Place> {
   const { data, error } = await supabase
     .from('trip_places')

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,6 +6,15 @@
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#0f172a",
+  "share_target": {
+    "action": "/share-target",
+    "method": "GET",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  },
   "icons": [
     {
       "src": "/icons/icon-192x192.png",

--- a/supabase/migrations/008_place_id.sql
+++ b/supabase/migrations/008_place_id.sql
@@ -1,0 +1,6 @@
+-- Migration 008: Add Google Place ID to trip_places
+-- Stores the canonical Google Place ID (e.g. ChIJN1t_tDeuEmsRUsoyG83frY4)
+-- extracted from Maps URLs. Used as a fallback key for Places Details API calls.
+
+alter table public.trip_places
+  add column if not exists place_id text;

--- a/types/index.ts
+++ b/types/index.ts
@@ -219,6 +219,7 @@ export interface Place {
   time_of_day: TimeOfDay | null
   duration: PlaceDuration | null
   meal_type: MealType | null
+  place_id: string | null
   created_by: string
   created_at: string
 }


### PR DESCRIPTION
## Summary
- `share.google` short links now resolve correctly — name extracted from `q=` param in the Google Search redirect URL
- `ChIJ` Place IDs extracted from full Maps URLs and stored in DB (`place_id` column, migration 008)
- `/api/places-details` route calls Google Places API (New, Basic fields only) as a fallback when URL parsing can't extract a clean name — only fires when needed to minimize cost
- Fixed `resolve-url` to use GET + browser User-Agent (HEAD requests were being silently ignored by Google's CDN)
- "Open in Maps" button added to all place cards (uses stored URL or lat/lng fallback)

## Migration required
Run `supabase/migrations/008_place_id.sql` in Supabase dashboard.

## Env var required
Add `GOOGLE_PLACES_API_KEY` to `.env.local` and Vercel — needs **Places API (New)** enabled, no application restrictions (server-to-server calls).

## Test plan
- [ ] Paste a `share.google/...` link into the Maps import field — should populate place name
- [ ] Paste a full `google.com/maps/place/...` URL — name + coordinates should populate
- [ ] Paste an `maps.app.goo.gl/...` link — should resolve and populate
- [ ] Place card with a stored URL shows the external link icon → opens Maps
- [ ] Run migration 008 and verify `place_id` column exists on `trip_places`

🤖 Generated with [Claude Code](https://claude.com/claude-code)