### PR TITLE
feat: Places as standalone page, rename Lists → Checklists

### DIFF
--- a/app/(app)/share-target/page.tsx
+++ b/app/(app)/share-target/page.tsx
@@ -11,7 +11,7 @@ import { isMapsUrl } from '@/lib/maps/parseGoogleMapsUrl'
  * When a user taps "Share" in Google Maps and selects Open Fly, the OS opens:
  *   /share-target?url=<maps-url>&title=<place-name>
  *
- * We find their most recent active trip and redirect to its Lists page
+ * We find their most recent active trip and redirect to its Places page
  * with the maps URL encoded in the query string so PlacesPanel can
  * auto-open the import dialog.
  */
@@ -48,7 +48,7 @@ export default function ShareTargetPage() {
       if (mapsLink) query.set('import_url', mapsLink)
       else if (title) query.set('import_url', text || url)
 
-      router.replace(`/trips/${tripId}/lists?${query.toString()}`)
+      router.replace(`/trips/${tripId}/places?${query.toString()}`)
     }
 
     handle()

--- a/app/(app)/trips/[tripId]/places/page.tsx
+++ b/app/(app)/trips/[tripId]/places/page.tsx
@@ -1,8 +1,8 @@
 import { createClient } from '@/lib/supabase/server'
 import * as ListController from '@/controllers/list.controller'
-import ChecklistPanel from '@/components/lists/ChecklistPanel'
+import PlacesPanel from '@/components/lists/PlacesPanel'
 
-export default async function ListsPage({
+export default async function PlacesPage({
   params,
 }: {
   params: Promise<{ tripId: string }>
@@ -12,9 +12,9 @@ export default async function ListsPage({
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return null
 
-  let checklistItems
+  let places
   try {
-    checklistItems = await ListController.getChecklistItems(tripId)
+    places = await ListController.getPlacesWithVotes(tripId, user.id)
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err)
     return (
@@ -31,10 +31,10 @@ export default async function ListsPage({
   return (
     <div>
       <div className="mb-6">
-        <h2 className="text-2xl font-bold text-foreground">Checklists</h2>
-        <p className="text-sm text-muted-foreground mt-0.5">Packing lists, groceries, souvenirs, and anything else to keep track of</p>
+        <h2 className="text-2xl font-bold text-foreground">Places to Visit</h2>
+        <p className="text-sm text-muted-foreground mt-0.5">Save and vote on restaurants, attractions, and activities for your trip</p>
       </div>
-      <ChecklistPanel tripId={tripId} initialItems={checklistItems} />
+      <PlacesPanel tripId={tripId} initialPlaces={places} />
     </div>
   )
 }

--- a/components/trips/MobileTripNav.tsx
+++ b/components/trips/MobileTripNav.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import {
-  Calendar, Map, ListTodo, FileText,
+  Calendar, Map, MapPin, ListTodo, FileText,
   DollarSign, Users, Plane, ChevronLeft, Settings, BookMarked, Menu,
 } from 'lucide-react'
 
@@ -23,7 +23,8 @@ const NAV_ITEMS = (base: string) => [
   { href: `${base}/flights`,          label: 'Flights',        icon: Plane },
   { href: `${base}/reservations`,     label: 'Reservations',   icon: BookMarked },
   { href: `${base}/map`,              label: 'Map',            icon: Map },
-  { href: `${base}/lists`,            label: 'Lists',          icon: ListTodo },
+  { href: `${base}/places`,           label: 'Places',         icon: MapPin },
+  { href: `${base}/lists`,            label: 'Checklists',     icon: ListTodo },
   { href: `${base}/documents`,        label: 'Documents',      icon: FileText },
   { href: `${base}/budget`,           label: 'Budget',         icon: DollarSign },
   { href: `${base}/collaboration`,    label: 'Collaboration',  icon: Users },

--- a/components/trips/TripSidebar.tsx
+++ b/components/trips/TripSidebar.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import {
-  Calendar, Map, ListTodo, FileText,
+  Calendar, Map, MapPin, ListTodo, FileText,
   DollarSign, Users, Plane, ChevronLeft, Settings, BookMarked,
 } from 'lucide-react'
 
@@ -19,7 +19,8 @@ const NAV_ITEMS = (base: string) => [
   { href: `${base}/flights`,          label: 'Flights',        icon: Plane },
   { href: `${base}/reservations`,     label: 'Reservations',   icon: BookMarked },
   { href: `${base}/map`,              label: 'Map',            icon: Map },
-  { href: `${base}/lists`,            label: 'Lists',          icon: ListTodo },
+  { href: `${base}/places`,           label: 'Places',         icon: MapPin },
+  { href: `${base}/lists`,            label: 'Checklists',     icon: ListTodo },
   { href: `${base}/documents`,        label: 'Documents',      icon: FileText },
   { href: `${base}/budget`,           label: 'Budget',         icon: DollarSign },
   { href: `${base}/collaboration`,    label: 'Collaboration',  icon: Users },


### PR DESCRIPTION
## Summary
- Moves Places to Visit out of the Lists tab into its own top-level nav page at `/places`
- Sidebar now: Itinerary → Flights → Reservations → Map → **Places** → **Checklists** → Documents → Budget → Collaboration
- Lists page renamed to "Checklists" (both the nav label and the page heading)
- PWA share target redirect updated to `/places` so Google Maps shares land in the right place

## Test plan
- [ ] Places nav item appears between Map and Checklists in sidebar and mobile nav
- [ ] `/trips/[id]/places` loads PlacesPanel correctly
- [ ] `/trips/[id]/lists` shows only Checklists — no more tabs
- [ ] Sharing from Google Maps via PWA opens the Places page

🤖 Generated with [Claude Code](https://claude.com/claude-code)